### PR TITLE
refactor: adjust product image scales and order

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
             { id: 'p-alc-10', name: 'Pitú Lata Sabor Limão e Mel 350ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão e Mel'}], imageUrl: 'https://i.ibb.co/nV8g7Hw/272835.webp', sortOrder: 26, active: true, imageClass: 'p-0' },
             { id: 'p-alc-11', name: 'Pitú Lata Sabor Caju 350ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Caju'}], imageUrl: 'https://i.ibb.co/7tZyg3Sb/D-Q-NP-810535-MLA90946626834-082025-O.webp', sortOrder: 27, active: true, imageClass: 'p-0' },
             { id: 'p-alc-12', name: 'Pitú Lata Sabor Banana 350 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Banana'}], imageUrl: 'https://i.ibb.co/SkDWw6Q/D-Q-NP-930648-MLA88192377865-072025-O.webp', sortOrder: 28, active: true, imageClass: 'p-0' },
-            { id: 'p-alc-13', name: 'Ice Pitú 275 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/q3yXhQVk/7896607100945.jpg', sortOrder: 29, active: true, imageClass: 'p-0' },
+            { id: 'p-alc-13', name: 'Ice Pitú 275 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/q3yXhQVk/7896607100945.jpg', sortOrder: 68, active: true, imageClass: 'p-0' },
             { id: 'p-alc-14', name: 'Cachaça Paratudo 900ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/mV5Jcph9/15126653667-1065-amargo-paratudo-900ml.jpg', sortOrder: 30, active: true, imageClass: 'p-0' },
             { id: 'p-alc-15', name: 'Cachaça Fogo Paulista 960ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/KjZr6XGT/7433-licor-dubar-fogo-paulista-960-ml.jpg', sortOrder: 31, active: true },
             { id: 'p-alc-16', name: 'Cachaça 51 de 965 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/7ttFj1hP/156261-1.jpg', sortOrder: 32, active: true, imageClass: 'p-0' },
@@ -288,9 +288,9 @@
             { id: 'p-alc-49', name: 'Gin Beefeater London Dry 900 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/gFc44xhq/Beefeater-London-Dry-Gin-aspect-ratio-320-540.jpg', sortOrder: 65, active: true, imageClass: 'p-0' },
             { id: 'p-alc-50', name: 'Genebra Dubar Zora 960 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/G4bPGLdH/51r-Oz-Lf4s-ML.jpg', sortOrder: 66, active: true, imageClass: 'p-0' },
             { id: 'p-alc-51', name: 'Geneva Steinhaeger Becosa 980 ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/C5m7hWwZ/51g-AZ7od-ZSL-UF1000-1000-QL80.jpg', sortOrder: 67, active: true, imageClass: 'p-0' },
-            { id: 'p-alc-52', name: 'Ice Syn Lemon Ice 300ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/WpjLmXH7/Syn-Ice-300-PET-Limao-25a1a95d.png', sortOrder: 68, active: true, imageClass: 'p-0' },
-            { id: 'p-alc-53', name: 'Ice Glow 275 ML (Garrafa de Vidro)', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/rC0thLK/Gemini-Generated-Image-bvkaw1bvkaw1bvka.png', sortOrder: 69, active: true, imageClass: 'p-0' },
-            { id: 'p-alc-54', name: 'Glow Ice 269ML (Lata)', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/YBgGsXmQ/glow-lata-269ml.png', sortOrder: 70, active: true, imageClass: 'p-4' },
+            { id: 'p-alc-52', name: 'Ice Syn Lemon Ice 300ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/WpjLmXH7/Syn-Ice-300-PET-Limao-25a1a95d.png', sortOrder: 69, active: true, imageClass: 'p-0' },
+            { id: 'p-alc-53', name: 'Ice Glow 275 ML (Garrafa de Vidro)', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/rC0thLK/Gemini-Generated-Image-bvkaw1bvkaw1bvka.png', sortOrder: 70, active: true, imageClass: 'p-0' },
+            { id: 'p-alc-54', name: 'Glow Ice 269ML (Lata)', category: 'Bebidas alcoólicas', details: [{flavor: 'Limão'}], imageUrl: 'https://i.ibb.co/YBgGsXmQ/glow-lata-269ml.png', sortOrder: 71, active: true, imageClass: 'p-4' },
             { id: 'p-alc-55', name: 'Vinho Quinta do Morgado Suave 750ML', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/j0dGyjr/quinta-do-morgado-tinto-suave.jpg', sortOrder: 71, active: true, imageClass: 'p-0' },
             { id: 'p-alc-56', name: 'Vinho Cantina da Serra 1L', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/DfmgKCmx/vinho-coquetel-cantina-da-serra-tinto-suave-embalagem-12x15-lt-preco-unitario-r9-3enygexapi.webp', sortOrder: 72, active: true, imageClass: 'p-0' },
             { id: 'p-alc-57', name: 'Vinho Pérgula Tinto Suave 1L', category: 'Bebidas alcoólicas', details: [{flavor: 'Tradicional'}], imageUrl: 'https://i.ibb.co/pjykdnSp/Vinho-Brasileiro-Pergola-Tinto-Suave-1l.png', sortOrder: 73, active: true, imageClass: 'p-0' },
@@ -691,18 +691,140 @@
             </div>
         );
 
+        // Zoom por produto:
+        // - "muito mais que os outros" => scale-150
+        // - "aumente muito" (padrão)   => scale-125
+        // - "só um pouco"              => scale-110
+        const SCALE_BY_NAME = new Map([
+          // --- SÓ UM POUCO ---
+          ["Refrigerante Goob 2L","scale-110"],
+          ["Glow Ice 269ML (Lata)","scale-110"],
+
+          // --- MUITO MAIS QUE OS OUTROS ---
+          ["Refrigerante Goob 230ML","scale-150"],
+          ["Energético Ener Up 2L","scale-150"],
+          ["Energético Ener Up 250ML","scale-150"],
+          ["Guaraná + Açaí Guaran Up de Copo 290ML","scale-150"],
+          ["Guaraná + Açaí Guaran Up 200ML","scale-150"],
+          ["Energético Ener Up lata 269 ML","scale-150"],
+          ["Pitú de Garrafa 600ML","scale-150"],
+
+          // --- AUMENTE MUITO (demais itens listados) ---
+          ["Refrigerante Goob 1L","scale-125"],
+          ["Suco Yulo 1,5L Frutas Cítricas","scale-125"],
+          // Suco Yulo 400ML NÃO escala (só deslocamento)
+          ["Pitú Litro Completa (Sem devolver o Litro)","scale-125"],
+          ["Pitú Devolvendo o Litro","scale-125"],
+          ["Pitú Lata 473ML","scale-125"],
+          ["Pitú Lata 350ML","scale-125"],
+          ["Pitú Lata Sabor Limão e Mel 350ML","scale-125"],
+          ["Pitú Lata Sabor Caju 350ML","scale-125"],
+          ["Pitú Lata Sabor Banana 350 ML","scale-125"],
+          ["Ice Pitú 275 ML","scale-125"],
+          ["Cachaça Paratudo 900ML","scale-125"],
+          ["Cachaça 51 de 965 ML","scale-125"],
+          ["Cachaça Asa Branca 900ML","scale-125"],
+          ["Cachaça Caninha Vida Nova 480 ML","scale-125"],
+          ["Cachaça Asa Branca Jequitibá 980 ML","scale-125"],
+          ["Cachaça Seleta 1 L","scale-125"],
+          ["Cachaça 1883 De Alambique Ouro 980 ML","scale-125"],
+          ["Vodka Slova Tradicional 965 ML","scale-125"],
+          ["Vodka Slova Sabor Limão 965 ML","scale-125"],
+          ["Vodka Slova Blueberry 965 ML","scale-125"],
+          ["Vodka Slova Sabor Frutas Vermelhas 965 ML","scale-125"],
+          ["Vodka Newsnoff 960 ML","scale-125"],
+          ["Vodka Newsnoff Sabor Limão 960 ML","scale-125"],
+          ["Vodka Newsnoff Sabor Frutas Vermelhas 960 ML","scale-125"],
+          ["Vodka Natasha 900 ML","scale-125"],
+          ["Vodka Smirnoff 1 L","scale-125"],
+          ["Vodka Absolut 1 L","scale-125"],
+          ["Whisky Black Stone 1L (Com Copo)","scale-125"],
+          ["Whisky Old Par 1L","scale-125"],
+          ["Whisky Jack Daniel’s 1L","scale-125"],
+          ["Whisky Jack Daniel’s Maçã Verde 1 L","scale-125"],
+          ["Whisky Jack Daniel’s Mel 1 L","scale-125"],
+          ["Whisky Red Label 1L","scale-125"],
+          ["Whisky Black Label 1 L","scale-125"],
+          ["Whisky Teachers 1L","scale-125"],
+          ["Whisky Passport Scotch 1L","scale-125"],
+          ["Whisky Chanceler 1L","scale-125"],
+          ["Whisky Ballantine’s 1L","scale-125"],
+          ["Whisky Black & White 1 L","scale-125"],
+          ["Gin Tanqueray London Dry 1 L","scale-125"],
+          ["Genebra Dubar Zora 960 ML","scale-125"],
+          ["Geneva Steinhaeger Becosa 980 ML","scale-125"],
+          ["Ice Syn Lemon Ice 300ML","scale-125"],
+          ["Ice Glow 275 ML (Garrafa de Vidro)","scale-125"],
+          ["Vinho Quinta do Morgado Suave 750ML","scale-125"],
+          ["Vinho Cantina da Serra 1L","scale-125"],
+          ["Vinho Pérgula Tinto Suave 1L","scale-125"],
+          ["Aperitivo Campari 900ML","scale-125"],
+          ["Aperitivo Jurubeba Leão do Norte 600 ML","scale-125"],
+          ["Conhaque Dramontt 900ML","scale-125"],
+          ["Conhaque Dreher 1L","scale-125"],
+          ["Conhaque Domecq Coquetel Composto 1 L","scale-125"],
+          ["Licor Menta São Paulo 960ML","scale-125"],
+          ["Catuaba Vida Nova 900ML","scale-125"],
+          ["Alcatrão São João da Barra 900 ML","scale-125"],
+          ["Bebida alcoólica Gengibre Vida Nova Verde 900ML","scale-125"],
+          ["Canelinha da Rocha 900ML","scale-125"],
+          ["Bala Icekiss Sortida 500G","scale-125"],
+          ["Bala Santa Fé Mastigável Yogurt Morango 500G","scale-125"],
+          ["Bala Santa Fé Mastigável Sortida Frutas 500G","scale-125"],
+          ["Balinhas Coração Morango Florestal 500G","scale-125"],
+          ["Bala Mel e Gengibre","scale-125"],
+          ["Bala de Hortelã Recheada","scale-125"],
+          ["Bala Coffee King","scale-125"],
+          ["Bala Azedinha","scale-125"],
+          ["Chiclete Trident","scale-125"],
+          ["Chiclete Cliss","scale-125"],
+          ["Chiclete Danclets Tutti Frutti","scale-125"],
+          ["Chiclete Blong","scale-125"],
+          ["Goma Tubo Gurt","scale-125"],
+          ["Goma Tubo Frutas Sortidas","scale-125"],
+          ["Pirulito Big Pop Frutas Recheado Mastigável 500 G","scale-125"],
+          ["Pirulito Megalito Sortido Berbau 1 KG","scale-125"],
+          ["Confeito Mamadeira","scale-125"],
+          ["Confeito Catavento","scale-125"],
+          ["Confeito Carinhas","scale-125"],
+          ["Confeito Chuquinhas","scale-125"],
+          ["Chup Chup Doce de Leite 750G","scale-125"],
+          ["Pé de Moleque Pacote com 50 unidades","scale-125"],
+          ["Pé de Moleque Pote com 50","scale-125"],
+          ["Cocada Branca","scale-125"],
+          ["Cocada Morena","scale-125"],
+          ["Goiabada de Pote","scale-125"],
+          ["Bananada de Pote","scale-125"],
+          ["Geleia de pote","scale-125"],
+          ["Pipoca Doce Goxtoso 40G","scale-125"],
+          ["Mendozitos Japonês 30G","scale-125"],
+          ["Amendoim Crocanty Pimenta Mexicana 30 G","scale-125"],
+          ["Amendoim Crocante Bacon 30G","scale-125"],
+          ["Amendoim Cebola e Salsa 30G","scale-125"],
+          ["Torresmo Pé de Serra","scale-125"],
+          ["Fumo Meliá","scale-125"],
+        ]);
+
+        // Deslocamento vertical p/ corrigir "flutuando"
+        const SHIFT_BY_NAME = new Map([
+          ["Refrigerante Goob 2L","translate-y-3"],  // empurra ~12px
+          ["Suco Yulo 400ML","translate-y-3"],       // sem zoom, só baixar
+        ]);
+
         const ProductCard = ({ product, onImageClick }) => {
             return (
-                <div 
+                <div
                     className="bg-white rounded-3xl shadow-md overflow-hidden flex flex-col transition-all duration-300 hover:shadow-2xl hover:-translate-y-2 h-full group cursor-pointer"
                     onClick={() => onImageClick(product.imageUrl)}
                 >
                     <div className="relative h-48 overflow-hidden bg-white flex items-center justify-center p-2">
-                        <img 
-                            loading="lazy" 
-                            src={product.imageUrl} 
-                            alt={product.name} 
-                            className={`max-w-full max-h-full object-contain transition-transform duration-300 group-hover:scale-105 ${product.imageClass || ''}`}
+                        <img
+                            loading="lazy"
+                            src={product.imageUrl}
+                            alt={product.name}
+                            className={`max-w-full max-h-full object-contain transform transition-transform duration-300 ${
+                                SCALE_BY_NAME.get(product.name) ? '' : 'group-hover:scale-105'
+                            } ${SCALE_BY_NAME.get(product.name) || ''} ${SHIFT_BY_NAME.get(product.name) || ''} ${product.imageClass || ''}`}
                         />
                     </div>
 


### PR DESCRIPTION
## Summary
- add granular SCALE_BY_NAME map with distinct zoom levels and SHIFT_BY_NAME for vertical offsets
- conditionally apply scale and shift classes in ProductCard images
- reorder ice beverages by updating sortOrder values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf686572988333b98092fb23331e37